### PR TITLE
Fix type piracy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraPDF"
 uuid = "e09e93a3-870c-4c75-9b71-3eefe58c6e5b"
 authors = ["Misha Mikhasenko"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,8 @@
 using Pkg
 cd(joinpath(@__DIR__, ".."))
 Pkg.activate("docs")
-Pkg.instantiate()
-Pkg.develop(path=".")
+Pkg.develop(PackageSpec(path=pwd()))  # adds the package that is being documented
+Pkg.instantiate()  # download & install dependences specific for the documentation
 
 using Documenter
 using AlgebraPDF
@@ -16,29 +16,29 @@ end
 
 gen_content_dir = joinpath(@__DIR__, "src")
 tutorial_src = joinpath(@__DIR__, "src", "tutorial_lit.jl")
-Literate.markdown(tutorial_src, gen_content_dir, name = "tutorial", documenter = true, credit = true, postprocess = fix_literate_output)
-Literate.notebook(tutorial_src, gen_content_dir, execute = false, name = "algebrapdf_tutorial", documenter = true, credit = true)
-Literate.script(tutorial_src, gen_content_dir, keep_comments = false, name = "algebrapdf_tutorial", documenter = true, credit = false)
+Literate.markdown(tutorial_src, gen_content_dir, name="tutorial", documenter=true, credit=true, postprocess=fix_literate_output)
+Literate.notebook(tutorial_src, gen_content_dir, execute=false, name="algebrapdf_tutorial", documenter=true, credit=true)
+Literate.script(tutorial_src, gen_content_dir, keep_comments=false, name="algebrapdf_tutorial", documenter=true, credit=false)
 
 
 makedocs(
     sitename="AlgebraPDF",
     modules=[AlgebraPDF],
-    format = Documenter.HTML(
-        prettyurls = true,
-        canonical = "https://mmikhasenko.github.io/AlgebraPDF.jl/stable/"
+    format=Documenter.HTML(
+        prettyurls=true,
+        canonical="https://mmikhasenko.github.io/AlgebraPDF.jl/stable/"
     ),
-    authors = "Mikhail Mikhasenko",
+    authors="Mikhail Mikhasenko",
     pages=[
         "Home" => "index.md",
         "Tutorial" => "tutorial.md",
         "API" => "api.md"
     ],
-    doctest = true,
-    linkcheck = false
+    doctest=false,
+    linkcheck=false
 )
 
 deploydocs(
     repo="github.com/mmikhasenko/AlgebraPDF.jl.git",
-    push_preview = true,
+    push_preview=true,
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -18,13 +18,12 @@ The additional type `FlaggedNamedTuple` allows to group parameters to `freed` an
 FlaggedNamedTuple
 ```
 
-The package introduces two operations on parameter types.
+The package introduces two operations on parameter types, `merge` and `subtract`.
+The `merge(nt1::NamedTuple, nt1::NamedTuple)` is defined in `Base`.
 
 ```@docs
-merge
 subtract
 ```
-
 
 ### Functions
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,9 +10,23 @@ There is a range of predefined functions
 implemented as a struct that holds tuple of parameters
 
 
+### Parameters
+
+The default parameter type is the `NamedTuple`. It holds parameter values and names and can update their value.
+The additional type `FlaggedNamedTuple` allows to group parameters to `freed` and `fixed`
+```@docs
+FlaggedNamedTuple
+```
+
+The package introduces two operations on parameter types.
+
+```@docs
+merge
+subtract
+```
+
 
 ### Functions
-
 
 Several common function are defined
 ```@docs

--- a/src/AlgebraPDF.jl
+++ b/src/AlgebraPDF.jl
@@ -18,7 +18,7 @@ export ∅
 const NumberOrTuple = Union{Number,Tuple{Vararg{Number}}}
 export NumberOrTuple
 
-import Base: +,-,*,==
+import Base: +, -, *, ==, merge
 import Base: getproperty
 import Base: getindex
 import Base: abs2, log
@@ -27,6 +27,7 @@ import Base: length
 # 
 # 
 export ParTypes
+export subtract
 include("parameters.jl")
 const Ext = FlaggedNamedTuple
 export Ext, FlaggedNamedTuple

--- a/src/arithmetics.jl
+++ b/src/arithmetics.jl
@@ -4,10 +4,10 @@
 struct FAbs2{T<:AbstractFunctionWithParameters} <: AbstractFunctionWithParameters
     f::T
 end
-func(d::FAbs2, x::NumberOrTuple; p=freepars(d)) = abs2(func(d.f,x;p))
+func(d::FAbs2, x::NumberOrTuple; p=freepars(d)) = abs2(func(d.f, x; p))
 pars(d::FAbs2, isfree::Bool) = pars(d.f, isfree)
-updatevalueorflag(d::FAbs2, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) =
-    FAbs2(updatevalueorflag(d.f,s,isfree,v))
+updatevalueorflag(d::FAbs2, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
+    FAbs2(updatevalueorflag(d.f, s, isfree, v))
 # 
 abs2(f::AbstractFunctionWithParameters) = FAbs2(f)
 
@@ -16,33 +16,33 @@ abs2(f::AbstractFunctionWithParameters) = FAbs2(f)
 struct FLog{T<:AbstractFunctionWithParameters} <: AbstractFunctionWithParameters
     f::T
 end
-func(d::FLog, x::NumberOrTuple; p=freepars(d)) = log(func(d.f,x;p))
+func(d::FLog, x::NumberOrTuple; p=freepars(d)) = log(func(d.f, x; p))
 pars(d::FLog, isfree::Bool) = pars(d.f, isfree)
-updatevalueorflag(d::FLog, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) =
-    FLog(updatevalueorflag(d.f,s,isfree,v))
+updatevalueorflag(d::FLog, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
+    FLog(updatevalueorflag(d.f, s, isfree, v))
 # 
 log(f::AbstractFunctionWithParameters) = FLog(f)
 
 ###################################################################### 
 
 struct FProd{
-        T1<:AbstractFunctionWithParameters,
-        T2<:AbstractFunctionWithParameters} <: AbstractFunctionWithParameters
+    T1<:AbstractFunctionWithParameters,
+    T2<:AbstractFunctionWithParameters} <: AbstractFunctionWithParameters
     f1::T1
     f2::T2
 end
-func(d::FProd, x::NumberOrTuple; p=freepars(d)) = func(d.f1,x;p) * func(d.f2,x;p)
-pars(d::FProd, isfree::Bool) = pars(d.f1, isfree) + pars(d.f2, isfree)
-updatevalueorflag(d::FProd, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) =
+func(d::FProd, x::NumberOrTuple; p=freepars(d)) = func(d.f1, x; p) * func(d.f2, x; p)
+pars(d::FProd, isfree::Bool) = merge(pars(d.f1, isfree), pars(d.f2, isfree))
+updatevalueorflag(d::FProd, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
     FProd(
-        ispar(d.f1,s) ? updatevalueorflag(d.f1,s,isfree,v) : d.f1,
-        ispar(d.f2,s) ? updatevalueorflag(d.f2,s,isfree,v) : d.f2)
+        ispar(d.f1, s) ? updatevalueorflag(d.f1, s, isfree, v) : d.f1,
+        ispar(d.f2, s) ? updatevalueorflag(d.f2, s, isfree, v) : d.f2)
 # 
-*(f1::AbstractFunctionWithParameters, f2::AbstractFunctionWithParameters) = FProd(f1,f2)
+*(f1::AbstractFunctionWithParameters, f2::AbstractFunctionWithParameters) = FProd(f1, f2)
 
 ###################################################################### 
 
-struct FSum{T<:AbstractFunctionWithParameters,N,V}  <: AbstractFunctionWithParameters
+struct FSum{T<:AbstractFunctionWithParameters,N,V} <: AbstractFunctionWithParameters
     fs::StaticVector{N,T}
     αs::V
 end
@@ -52,81 +52,81 @@ function FSum(fs::Union{Tuple,AbstractVector}, αs)
 end
 # 
 length(d::FSum{T,N}) where {T,N} = N
-pars(d::FSum, isfree::Bool) = sum(pars.(d.fs, isfree)) + pars(d.αs, isfree)
+pars(d::FSum, isfree::Bool) = merge(pars.(d.fs, isfree)..., pars(d.αs, isfree))
 function getindex(d::FSum, i::Number)
     α_sym = keys(d.αs)[i]
     α_val = getproperty(d.αs, α_sym)
     FSum([d.fs[i]], nt(α_sym, α_val))
 end
-const FSumFunc = AlgebraPDF.FSum{T} where T<:AbstractFunctionWithParameters
-const FSumPDF = AlgebraPDF.FSum{T} where T<:AbstractPDF
+const FSumFunc = AlgebraPDF.FSum{T} where {T<:AbstractFunctionWithParameters}
+const FSumPDF = AlgebraPDF.FSum{T} where {T<:AbstractPDF}
 
 function func(d::FSumFunc, x::NumberOrTuple; p=freepars(d))
-    allp = p+fixedpars(d)
-    α_vals = (getproperty(allp,s) for s in keys(d.αs))
-    f_vals = func.(d.fs, Ref(x);p)
-    return sum(α_vals .* f_vals)   
+    allp = merge(p, fixedpars(d))
+    α_vals = (getproperty(allp, s) for s in keys(d.αs))
+    f_vals = func.(d.fs, Ref(x); p)
+    return sum(α_vals .* f_vals)
 end
 
 function dividenorm(d::AbstractFunctionWithParameters, Nsymb::Symbol, lims)
-    I = quadgk(x->func(d, x), lims...)[1]
-    FSum([d], NamedTuple{(Nsymb,)}(1/I))
+    I = quadgk(x -> func(d, x), lims...)[1]
+    FSum([d], NamedTuple{(Nsymb,)}(1 / I))
 end
 # lambda version
-dividenorm(Nsymb::Symbol, lims) = d->dividenorm(d, Nsymb, lims)
+dividenorm(Nsymb::Symbol, lims) = d -> dividenorm(d, Nsymb, lims)
 
 # 
 function func_norm(d::FSumPDF, x; p=freepars(d)) # suppose to work also for all x <: AbstractVector
-    allp = p+fixedpars(d)
-    α_vals = (getproperty(allp,s) for s in keys(d.αs))
-    f_vals = [f(x;p) for f in d.fs]
+    allp = merge(p, fixedpars(d))
+    α_vals = (getproperty(allp, s) for s in keys(d.αs))
+    f_vals = [f(x; p) for f in d.fs]
     return sum(α_vals .* f_vals)
 end
-func(d::FSumPDF, x::NumberOrTuple; p=freepars(d)) = func_norm(d,x;p)
-func(d::FSumPDF, x::AbstractArray; p=freepars(d)) = func_norm(d,x;p)
-func(d::FSumPDF, x::AbstractRange; p=freepars(d)) = func_norm(d,x;p)
+func(d::FSumPDF, x::NumberOrTuple; p=freepars(d)) = func_norm(d, x; p)
+func(d::FSumPDF, x::AbstractArray; p=freepars(d)) = func_norm(d, x; p)
+func(d::FSumPDF, x::AbstractRange; p=freepars(d)) = func_norm(d, x; p)
 lims(d::FSumPDF) = lims(d.fs[1])
 
-function updatevalueorflag(d::FSum, s::Symbol, isfree::Bool, v=getproperty(pars(d),s))
-    fs = [ispar(f,s) ? updatevalueorflag(f,s,isfree,v) : f for f in d.fs]
-    αs = ispar(d.αs,s) ? updatevalueorflag(d.αs,s,isfree,v) : d.αs
+function updatevalueorflag(d::FSum, s::Symbol, isfree::Bool, v=getproperty(pars(d), s))
+    fs = [ispar(f, s) ? updatevalueorflag(f, s, isfree, v) : f for f in d.fs]
+    αs = ispar(d.αs, s) ? updatevalueorflag(d.αs, s, isfree, v) : d.αs
     FSum(fs, αs)
 end
 #
 function integral(d::FSumPDF; p=freepars(d.αs))
-    allp = p+fixedpars(d.αs)
-    sum(getproperty(allp,s) for s in keys(d.αs))
+    allp = merge(p, fixedpars(d.αs))
+    sum(getproperty(allp, s) for s in keys(d.αs))
 end
 
 function integral(d::FSumPDF, lims; p=freepars(d))
-    allp = p+fixedpars(d)
-    α_vals = (getproperty(allp,s) for s in keys(d.αs))
+    allp = merge(p, fixedpars(d))
+    α_vals = (getproperty(allp, s) for s in keys(d.αs))
     f_vals = integral.(d.fs, Ref(lims); p)
     return sum(α_vals .* f_vals)
 end
 
 +(f1::AbstractFunctionWithParameters,
-  f2::AbstractFunctionWithParameters; p=(α1=1.0, α2=1.0)) = FSum([f1,f2], p)
+    f2::AbstractFunctionWithParameters; p=(α1=1.0, α2=1.0)) = FSum([f1, f2], p)
 
 -(f1::AbstractFunctionWithParameters,
-  f2::AbstractFunctionWithParameters; p=(α1=1.0, α2=-1.0)) = FSum([f1,f2], p)
+    f2::AbstractFunctionWithParameters; p=(α1=1.0, α2=-1.0)) = FSum([f1, f2], p)
 
-+(f1::FSum, f2::FSum) = FSum([f1.fs...,f2.fs...], f1.αs+f2.αs)
++(f1::FSum, f2::FSum) = FSum([f1.fs..., f2.fs...], merge(f1.αs, f2.αs))
 
 *(f::AbstractFunctionWithParameters, c::ParTypes) = FSum([f], c)
 *(c::ParTypes, f::AbstractFunctionWithParameters) = FSum([f], c)
 
 ###################################################################### 
 
-struct NegativeLogLikelihood{T<:AbstractFunctionWithParameters, D<:AbstractArray} <: AbstractFunctionWithParameters
+struct NegativeLogLikelihood{T<:AbstractFunctionWithParameters,D<:AbstractArray} <: AbstractFunctionWithParameters
     f::T
     data::D
     nagativepenatly::Float64
 end
-func(d::NegativeLogLikelihood, x::NumberOrTuple; p=freepars(d)) = -sum((v>0) ? log(v) : d.nagativepenatly for v in d.f(d.data;p))
+func(d::NegativeLogLikelihood, x::NumberOrTuple; p=freepars(d)) = -sum((v > 0) ? log(v) : d.nagativepenatly for v in d.f(d.data; p))
 pars(d::NegativeLogLikelihood, isfree::Bool) = pars(d.f, isfree)
-updatevalueorflag(d::NegativeLogLikelihood, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) =
-    NegativeLogLikelihood(updatevalueorflag(d.f,s,isfree,v), d.data, d.nagativepenatly)
+updatevalueorflag(d::NegativeLogLikelihood, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
+    NegativeLogLikelihood(updatevalueorflag(d.f, s, isfree, v), d.data, d.nagativepenatly)
 #
 NegativeLogLikelihood(d, data::AbstractArray) = NegativeLogLikelihood(d, data, -1e4)
 minussum(d::FLog, data::AbstractArray) = NegativeLogLikelihood(d.f, data)
@@ -134,13 +134,13 @@ minussum(d::FLog, data::AbstractArray) = NegativeLogLikelihood(d.f, data)
 
 ###################################################################### 
 
-struct Extended{T <: AlgebraPDF.FSumPDF} <: AbstractFunctionWithParameters
+struct Extended{T<:AlgebraPDF.FSumPDF} <: AbstractFunctionWithParameters
     nll::NegativeLogLikelihood{T}
 end
 
 pars(d::Extended, isfree::Bool) = pars(d.nll, isfree)
-updatevalueorflag(d::Extended, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) =
-    Extended(updatevalueorflag(d.nll,s,isfree,v))
+updatevalueorflag(d::Extended, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
+    Extended(updatevalueorflag(d.nll, s, isfree, v))
 # 
 function func(d::Extended, x::NumberOrTuple; p=freepars(d))
     nll = func(d.nll, x; p)
@@ -165,11 +165,11 @@ func(d::ChiSq, x::NumberOrTuple; p=pars(d)) =
     sum((d.yv - d.f(d.xv; p)) .^ 2 ./ d.dyv .^ 2)
 # 
 pars(d::ChiSq, isfree::Bool) = pars(d.f, isfree)
-updatevalueorflag(d::ChiSq, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) =
-    ChiSq(updatevalueorflag(d.f,s,isfree,v), d.xv, d.yv)
+updatevalueorflag(d::ChiSq, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
+    ChiSq(updatevalueorflag(d.f, s, isfree, v), d.xv, d.yv)
 #
-ChiSq(f, xv::Vector{<:NumberOrTuple}, yv::Vector{V}) where V<:Number =
-    ChiSq(f, xv, yv, ones(V,length(yv)))
+ChiSq(f, xv::Vector{<:NumberOrTuple}, yv::Vector{V}) where {V<:Number} =
+    ChiSq(f, xv, yv, ones(V, length(yv)))
 # 
 model(χ²::ChiSq) = χ².f
 

--- a/src/convolution.jl
+++ b/src/convolution.jl
@@ -3,16 +3,16 @@ struct convGauss{T,S} <: AbstractPDF{1}
     σ::S
 end
 
-pars(d::convGauss, isfree::Bool) = pars(d.source, isfree) + pars(d.σ, isfree)
+pars(d::convGauss, isfree::Bool) = merge(pars(d.source, isfree), pars(d.σ, isfree))
 lims(d::convGauss) = lims(d.source)
-updatevalueorflag(d::convGauss, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) = 
+updatevalueorflag(d::convGauss, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
     convGauss(
-        ispar(d.source,s) ? updatevalueorflag(d.source,s,isfree,v) : d.source,
-        ispar(d.σ,     s) ? updatevalueorflag(d.σ,     s,isfree,v) : d.σ)
+        ispar(d.source, s) ? updatevalueorflag(d.source, s, isfree, v) : d.source,
+        ispar(d.σ, s) ? updatevalueorflag(d.σ, s, isfree, v) : d.σ)
 
 function func(d::convGauss, x::NumberOrTuple; p=pars(d))
     σ = func(d.σ, x; p)
     g(z) = AlgebraPDF.standardgauss(z, σ)
     f(z) = func(d.source, z; p)
-    return quadgk(y->f(x-y) * g(y), -5*σ, +5*σ)[1]
+    return quadgk(y -> f(x - y) * g(y), -5 * σ, +5 * σ)[1]
 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -4,7 +4,7 @@
     subtract(t1::NamedTuple, ss::AbstractVector{Symbol})
     subtract(t1::NamedTuple, ss::Tuple{Vararg{Symbol}}) 
 
-The function is used to remove the parameters from the NamedTuple that are given by the second argument.
+Remove parameters from the NamedTuple that are given by the second argument.
 It can be a single symbol, a vector of symbols or a tuple of symbols.
 
 # Examples

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -61,10 +61,38 @@ updatevalueorflag(p::NamedTuple, s::Symbol, isfree::Bool, v=getproperty(pars(p),
 #      _|_|    _|      _|        _|    _|  _|          _|      
 #  _|_|_|        _|_|  _|          _|_|_|    _|_|_|      _|_|  
 
+"""
+    FlaggedNamedTuple(t::NamedTuple) = FlaggedNamedTuple(t, ())
+    FlaggedNamedTuple(ps::FlaggedNamedTuple) = FlaggedNamedTuple(allpars(ps), whichfixed(ps))
+    FlaggedNamedTuple(; kw...) = FlaggedNamedTuple((; kw...))
+    
+immutable type that holds a NamedTuple of parameters and a tuple of symbols that indicates which parameters are fixed.
+The short alias for the `FlaggedNamedTuple` is `Ext`.
+
+# Examples
+```jldoctest
+julia> ps = FlaggedNamedTuple((a=1,b=2,c=3), (:a, :b))  # a and b are fixed 
+FlaggedNamedTuple{(:a, :b)}((a = 1, b = 2, c = 3), (:a, :b))
+
+julia> freepars(ps)
+(c = 3,)
+
+julia> fixedpars(ps)
+(a = 1, b = 2)
+
+julia> ps == Ext((a = 1, b = 2, c = 3), (:a, :b))
+true
+```
+"""
 struct FlaggedNamedTuple{R}
     allpars::NamedTuple{R}
     whichfixed::Tuple{Vararg{Symbol}}
 end
+
+FlaggedNamedTuple(t::NamedTuple) = FlaggedNamedTuple(t, ())
+FlaggedNamedTuple(ps::FlaggedNamedTuple) = FlaggedNamedTuple(allpars(ps), whichfixed(ps))
+FlaggedNamedTuple(; kw...) = FlaggedNamedTuple((; kw...))
+
 allpars(ps::FlaggedNamedTuple) = getfield(ps, :allpars)
 whichfixed(ps::FlaggedNamedTuple) = getfield(ps, :whichfixed)
 
@@ -97,10 +125,6 @@ merge(s1::FlaggedNamedTuple, s2::FlaggedNamedTuple) =
     FlaggedNamedTuple(merge(allpars(s1), allpars(s2)), (whichfixed(s1)..., whichfixed(s2)...))
 merge(s1::FlaggedNamedTuple, s2::NamedTuple) = merge(s1, FlaggedNamedTuple(s2))
 merge(s1::NamedTuple, s2::FlaggedNamedTuple) = merge(FlaggedNamedTuple(s1), s2)
-# 
-FlaggedNamedTuple(t::NamedTuple) = FlaggedNamedTuple(t, ())
-FlaggedNamedTuple(ps::FlaggedNamedTuple) = FlaggedNamedTuple(allpars(ps), whichfixed(ps))
-FlaggedNamedTuple(; kw...) = FlaggedNamedTuple((; kw...))
 #
 const ParTypes = Union{NamedTuple,FlaggedNamedTuple}
 # 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -70,8 +70,8 @@ julia> freepars(ps)
 julia> fixedpars(ps)
 (a = 1, b = 2)
 
-julia> ps == Ext((a = 1, b = 2, c = 3), (:a, :b))
-true
+julia> Ext((a = 2.2,)).a
+2.2
 ```
 """
 struct FlaggedNamedTuple{R}

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -8,27 +8,17 @@ The function is used to remove the parameters from the NamedTuple that are given
 It can be a single symbol, a vector of symbols or a tuple of symbols.
 
 # Examples
-```julia-repl
+```jldoctest
 julia> (a=1,b=2,d=1,c=2) - (d=1,)
-
 (a=1,b=2,c=2)
-```
 
-```julia-repl
 julia> (a=1,b=2,d=1,c=2) - :d
-
 (a=1,b=2,c=2)
-```
 
-```julia-repl
 julia> (a=1,b=2,d=1,c=2) - [:d, :a]
-
 (b=2,c=2)
-```
 
-```julia-repl
 julia> (a=1,b=2,d=1,c=2) - (:d, :a)
-
 (b=2,c=2)
 ```
 """

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -9,16 +9,16 @@ It can be a single symbol, a vector of symbols or a tuple of symbols.
 
 # Examples
 ```jldoctest
-julia> (a=1,b=2,d=1,c=2) - (d=1,)
+julia> subtract((a=1,b=2,d=1,c=2), (d=1,))
 (a=1,b=2,c=2)
 
-julia> (a=1,b=2,d=1,c=2) - :d
+julia> subtract((a=1,b=2,d=1,c=2), :d)
 (a=1,b=2,c=2)
 
-julia> (a=1,b=2,d=1,c=2) - [:d, :a]
+julia> subtract((a=1,b=2,d=1,c=2), [:d, :a])
 (b=2,c=2)
 
-julia> (a=1,b=2,d=1,c=2) - (:d, :a)
+julia> subtract((a=1,b=2,d=1,c=2), (:d, :a))
 (b=2,c=2)
 ```
 """

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,8 +1,42 @@
-+(t1::NamedTuple, t2::NamedTuple) = merge(t1,t2)
--(t1::NamedTuple, t2::NamedTuple) = Base.structdiff(t1,t2)
--(t1::NamedTuple, s::Symbol) = Base.structdiff(t1, nt(s))
--(t1::NamedTuple, ss::AbstractVector{Symbol}) = Base.structdiff(t1, sum(nt.(ss)))
--(t1::NamedTuple, ss::Tuple{Vararg{Symbol}}) = Base.structdiff(t1, sum(nt.(ss)))
+"""
+    subtract(t1::NamedTuple, t2::NamedTuple)
+    subtract(t1::NamedTuple, s::Symbol)
+    subtract(t1::NamedTuple, ss::AbstractVector{Symbol})
+    subtract(t1::NamedTuple, ss::Tuple{Vararg{Symbol}}) 
+
+The function is used to remove the parameters from the NamedTuple that are given by the second argument.
+It can be a single symbol, a vector of symbols or a tuple of symbols.
+
+# Examples
+```julia-repl
+julia> (a=1,b=2,d=1,c=2) - (d=1,)
+
+(a=1,b=2,c=2)
+```
+
+```julia-repl
+julia> (a=1,b=2,d=1,c=2) - :d
+
+(a=1,b=2,c=2)
+```
+
+```julia-repl
+julia> (a=1,b=2,d=1,c=2) - [:d, :a]
+
+(b=2,c=2)
+```
+
+```julia-repl
+julia> (a=1,b=2,d=1,c=2) - (:d, :a)
+
+(b=2,c=2)
+```
+"""
+subtract(t1::NamedTuple, t2::NamedTuple) = Base.structdiff(t1, t2)
+subtract(t1::NamedTuple, s::Symbol) = Base.structdiff(t1, nt(s))
+subtract(t1::NamedTuple, ss::AbstractVector{Symbol}) = Base.structdiff(t1, NamedTuple{Tuple(ss)}(zeros(length(ss))))
+subtract(t1::NamedTuple, ss::Tuple{Vararg{Symbol}}) = Base.structdiff(t1, NamedTuple{ss}(zeros(length(ss))))
+
 
 #    _|                          _|            
 #  _|_|_|_|  _|    _|  _|_|_|    _|    _|_|    
@@ -13,12 +47,12 @@
 #                      _|                      
 
 
-pars(ps::NamedTuple, isfree::Bool) = isfree==true ? ps : ∅
+pars(ps::NamedTuple, isfree::Bool) = isfree == true ? ps : ∅
 # 
 selectintersect(p::NamedTuple, from_p::NamedTuple) = selectpars(from_p, intersect(keys(p), keys(from_p)))
 
-updatevalueorflag(p::NamedTuple, s::Symbol, isfree::Bool, v=getproperty(pars(p),s)) =
-    isfree==true ? NamedTuple{keys(p)}(p+nt(s,v)) : # join and replace the old value
+updatevalueorflag(p::NamedTuple, s::Symbol, isfree::Bool, v=getproperty(pars(p), s)) =
+    isfree == true ? NamedTuple{keys(p)}(merge(p, nt(s, v))) : # join and replace the old value
     throw(ArgumentError("Not able to fix, release parameters since parameters are held by a NamedTuple!"))
 
 #              _|                                      _|      
@@ -26,27 +60,27 @@ updatevalueorflag(p::NamedTuple, s::Symbol, isfree::Bool, v=getproperty(pars(p),
 #  _|_|        _|      _|_|      _|    _|  _|          _|      
 #      _|_|    _|      _|        _|    _|  _|          _|      
 #  _|_|_|        _|_|  _|          _|_|_|    _|_|_|      _|_|  
-                                                             
+
 struct FlaggedNamedTuple{R}
     allpars::NamedTuple{R}
     whichfixed::Tuple{Vararg{Symbol}}
 end
-allpars(ps::FlaggedNamedTuple) = getfield(ps,:allpars)
-whichfixed(ps::FlaggedNamedTuple) = getfield(ps,:whichfixed)
+allpars(ps::FlaggedNamedTuple) = getfield(ps, :allpars)
+whichfixed(ps::FlaggedNamedTuple) = getfield(ps, :whichfixed)
 
 keys(ps::FlaggedNamedTuple) = keys(allpars(ps))
-keys(ps::FlaggedNamedTuple, isfree::Bool) = isfree==false ? whichfixed(ps) : Base.diff_names(keys(allpars(ps)), whichfixed(ps))
+keys(ps::FlaggedNamedTuple, isfree::Bool) = isfree == false ? whichfixed(ps) : Base.diff_names(keys(allpars(ps)), whichfixed(ps))
 pars(ps::FlaggedNamedTuple, isfree::Bool) = NamedTuple{keys(ps, isfree)}(allpars(ps))
 
 getproperty(ps::FlaggedNamedTuple, s::Symbol) = hasproperty(freepars(ps), s) ? getproperty(freepars(ps), s) : getproperty(fixedpars(ps), s)
 
 
 # inner working
-updatednamedtuple(p::NamedTuple, s::Symbol, v) = NamedTuple{keys(p)}(p+nt(s,v))
-mustinclude(whichfixed::Tuple{Vararg{Symbol}},s) = s ∈ whichfixed ? whichfixed : (whichfixed...,s)
-mustexclude(whichfixed::Tuple{Vararg{Symbol}},s) = s ∈ whichfixed ? Base.diff_names(whichfixed, (s,)) : whichfixed
+updatednamedtuple(p::NamedTuple, s::Symbol, v) = NamedTuple{keys(p)}(merge(p, nt(s, v)))
+mustinclude(whichfixed::Tuple{Vararg{Symbol}}, s) = s ∈ whichfixed ? whichfixed : (whichfixed..., s)
+mustexclude(whichfixed::Tuple{Vararg{Symbol}}, s) = s ∈ whichfixed ? Base.diff_names(whichfixed, (s,)) : whichfixed
 function updateflag(whichfixed::Tuple{Vararg{Symbol}}, s::Symbol, isfree::Bool)
-    isfree ? mustexclude(whichfixed,s) : mustinclude(whichfixed,s)
+    isfree ? mustexclude(whichfixed, s) : mustinclude(whichfixed, s)
 end
 
 """
@@ -54,23 +88,23 @@ end
 
 Implementation of the main update method for `FlaggedNamedTuple` parameters.
 """
-function updatevalueorflag(p::FlaggedNamedTuple, s::Symbol, isfree::Bool, v=getproperty(pars(p),s))
+function updatevalueorflag(p::FlaggedNamedTuple, s::Symbol, isfree::Bool, v=getproperty(pars(p), s))
     return FlaggedNamedTuple(
-        updatednamedtuple(allpars(p),s,v),
+        updatednamedtuple(allpars(p), s, v),
         updateflag(whichfixed(p), s, isfree))
 end
-+(s1::FlaggedNamedTuple, s2::FlaggedNamedTuple) =
-    FlaggedNamedTuple(allpars(s1)+allpars(s2), (whichfixed(s1)...,whichfixed(s2)...))
-+(s1::FlaggedNamedTuple, s2::NamedTuple) = s1+FlaggedNamedTuple(s2)
-+(s1::NamedTuple, s2::FlaggedNamedTuple) = FlaggedNamedTuple(s1)+s2
+merge(s1::FlaggedNamedTuple, s2::FlaggedNamedTuple) =
+    FlaggedNamedTuple(merge(allpars(s1), allpars(s2)), (whichfixed(s1)..., whichfixed(s2)...))
+merge(s1::FlaggedNamedTuple, s2::NamedTuple) = merge(s1, FlaggedNamedTuple(s2))
+merge(s1::NamedTuple, s2::FlaggedNamedTuple) = merge(FlaggedNamedTuple(s1), s2)
 # 
-FlaggedNamedTuple(t::NamedTuple) = FlaggedNamedTuple(t,())
-FlaggedNamedTuple(ps::FlaggedNamedTuple) = FlaggedNamedTuple(allpars(ps),whichfixed(ps))
-FlaggedNamedTuple(; kw...) = FlaggedNamedTuple((;kw...))
+FlaggedNamedTuple(t::NamedTuple) = FlaggedNamedTuple(t, ())
+FlaggedNamedTuple(ps::FlaggedNamedTuple) = FlaggedNamedTuple(allpars(ps), whichfixed(ps))
+FlaggedNamedTuple(; kw...) = FlaggedNamedTuple((; kw...))
 #
 const ParTypes = Union{NamedTuple,FlaggedNamedTuple}
 # 
-pars(ps::ParTypes) = NamedTuple{keys(ps)}(pars(ps, true) + pars(ps, false))
+pars(ps::ParTypes) = NamedTuple{keys(ps)}(merge(pars(ps, true), pars(ps, false)))
 freepars(d::ParTypes) = pars(d, true)
 fixedpars(d::ParTypes) = pars(d, false)
 #

--- a/src/pdf.jl
+++ b/src/pdf.jl
@@ -5,7 +5,7 @@
 #  _|_|_|_|  _|    _|  _|_|        _|      _|_|      _|    _|  _|          _|      _|_|_|    _|    _|  _|_|_|    
 #  _|    _|  _|    _|      _|_|    _|      _|        _|    _|  _|          _|      _|        _|    _|  _|        
 #  _|    _|  _|_|_|    _|_|_|        _|_|  _|          _|_|_|    _|_|_|      _|_|  _|        _|_|_|    _|        
-                                                                                                               
+
 
 abstract type AbstractPDF{N} <: AbstractFunctionWithParameters end  # N is the dimension
 
@@ -16,14 +16,14 @@ function (d::AbstractPDF)(x; p=freepars(d))
         println("Error: normalization ≈ 0!")
         normalization = 1.0
     end
-    allp = p+fixedpars(d)
-    return func(d,x; p=allp) / normalization
+    allp = merge(p, fixedpars(d))
+    return func(d, x; p=allp) / normalization
 end
 
 # 1 dims
 function normalizationintegral(d::AbstractPDF{1}; p=freepars(d))
-    allp = p+fixedpars(d)
-    quadgk(x->func(d, x; p=allp), lims(d)...)[1]
+    allp = merge(p, fixedpars(d))
+    quadgk(x -> func(d, x; p=allp), lims(d)...)[1]
 end
 #
 # 2 dims
@@ -37,19 +37,19 @@ end
     noparsnormf(d::AbstractPDF; p=pars(d))
 
 Returns a single-argument lambda-function with parameters fixed to `p` and normalization computed.
-""" 
-noparsnormf(d::AbstractPDF; p=pars(d)) = (ns=normalizationintegral(d;p=p); (x;kw...)->func(d,x;p=p)/ns)
+"""
+noparsnormf(d::AbstractPDF; p=pars(d)) = (ns = normalizationintegral(d; p=p); (x; kw...) -> func(d, x; p=p) / ns)
 
 
 # by default, I assume that the fields "lims" is present
 lims(d::AbstractPDF) = getfield(d, :lims)
-updatevalueorflag(d::AbstractPDF, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) =
+updatevalueorflag(d::AbstractPDF, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
     typeof(d)(updatevalueorflag(d.p, s, isfree, v), d.lims)
 
 # other methods
 function integral(d::AbstractPDF{1}, lims; p=freepars(d))
-    allpars = p+fixedpars(d)
-    quadgk(x->func(d,x; p=allpars), lims...)[1] / normalizationintegral(d; p=allpars)
+    allpars = merge(p, fixedpars(d))
+    quadgk(x -> func(d, x; p=allpars), lims...)[1] / normalizationintegral(d; p=allpars)
 end
 
 #################################################################### 
@@ -62,20 +62,20 @@ lineshape(d::Normalized) = getfield(d, :lineshape)
 
 # two methods to be defined
 import Base: getproperty
-getproperty(d::Normalized, sym::Symbol) = sym==:p ? pars(lineshape(d)) : getfield(d, sym)
+getproperty(d::Normalized, sym::Symbol) = sym == :p ? pars(lineshape(d)) : getfield(d, sym)
 func(d::Normalized, x::NumberOrTuple; p=pars(d)) = func(lineshape(d), x; p)
 pars(d::Normalized, isfree::Bool) = pars(lineshape(d), isfree)
-updatevalueorflag(d::Normalized, s::Symbol, isfree::Bool, v=getproperty(pars(d),s)) =
+updatevalueorflag(d::Normalized, s::Symbol, isfree::Bool, v=getproperty(pars(d), s)) =
     Normalized(updatevalueorflag(lineshape(d), s, isfree, v), d.lims)
 
 
 # short cuts
 # 1 argument
-Normalized(lims::L) where L = f->Normalized(f, lims)
+Normalized(lims::L) where {L} = f -> Normalized(f, lims)
 
 ###################################################################### 
 
-fixedshapepdf(f, lims) = Normalized(FunctionWithParameters((x;p)->f(x); p=∅), lims)
+fixedshapepdf(f, lims) = Normalized(FunctionWithParameters((x; p) -> f(x); p=∅), lims)
 
 ###################################################################### 
 
@@ -98,7 +98,7 @@ macro makepdftype(ex)
     fpx = ex.args[1].args
     name = fpx[1]
     p = fpx[2].args[1]
-    (p != :p) && error("expected format f(x;p) = ... " )
+    (p != :p) && error("expected format f(x;p) = ... ")
     x = fpx[3]
     body = ex.args[2]
     # 
@@ -107,10 +107,10 @@ macro makepdftype(ex)
             p::T
             lims::N
         end
-        $(esc(name))(;p,lims) = $(esc(name))(p, lims)
+        $(esc(name))(; p, lims) = $(esc(name))(p, lims)
 
         $(esc(:(AlgebraPDF.func)))(d::$(esc(name)), $(esc(x))::NumberOrTuple;
             p=$(esc(:(AlgebraPDF.pars)))(d)) =
-                $(esc(body))
+            $(esc(body))
     end
 end

--- a/test/testfuncions.jl
+++ b/test/testfuncions.jl
@@ -5,32 +5,32 @@ using QuadGK
 
 @testset "FunctionWithParameters{NamedTuples}" begin
     d0 = FunctionWithParameters(
-        (x;p)->p.a+cos(x)*p.b;
-        p=(a=2,b=1))
+        (x; p) -> p.a + cos(x) * p.b;
+        p=(a=2, b=1))
     # 
-    @test freepars(d0) == (a=2,b=1)
+    @test freepars(d0) == (a=2, b=1)
     @test fixedpars(d0) == ∅
-    @test pars(d0) == (a=2,b=1)
+    @test pars(d0) == (a=2, b=1)
 
     @test nfreepars(d0) == 2
 
-    @test func(d0,0) == 3
-    @test func(d0,repeat([0],10)) == repeat([3],10)
+    @test func(d0, 0) == 3
+    @test func(d0, repeat([0], 10)) == repeat([3], 10)
     @test func(d0, 1:10) == func(d0, collect(1:10))
 
     d1 = updatepar(d0, :a, 4)
-    @test freepars(d1) == (a=4,b=1)
+    @test freepars(d1) == (a=4, b=1)
     @test releasepar(d0, :b) == d0
     @test_throws ArgumentError fixpar(d0, :b)
     # 
-    @test v2p([1,2],d0) == (a=1,b=2)
-    @test p2v(d0) == [2,1]
-    @test p2v((b=6,a=5,c=33), d0) == [5,6]    
+    @test v2p([1, 2], d0) == (a=1, b=2)
+    @test p2v(d0) == [2, 1]
+    @test p2v((b=6, a=5, c=33), d0) == [5, 6]
 end
 
 @testset "FunctionWithParameters{FlaggedNamedTuple}" begin
     g = FunctionWithParameters(
-        (x;p)->exp((x-p.μ)^3/(2*p.σ^2));
+        (x; p) -> exp((x - p.μ)^3 / (2 * p.σ^2));
         p=Ext(μ=1.2, σ=0.1))
     # 
     g′ = fixpar(g, :μ)
@@ -52,11 +52,11 @@ end
 
 @testset "FunctionWithParameters{FlaggedNamedTuple}" begin
     m0 = FunctionWithParameters(
-        (x;p)->p.a+cos(x)*p.b;
-        p=Ext(a=2,b=1))
+        (x; p) -> p.a + cos(x) * p.b;
+        p=Ext(a=2, b=1))
     #
     m1 = updatepar(m0, :a, 4)
-    @test freepars(m1) == (a=4,b=1)
+    @test freepars(m1) == (a=4, b=1)
 
     m2 = fixpar(m1, :a)
     @test freepars(m2) == (b=1,)
@@ -65,27 +65,27 @@ end
     m3 = releasepar(m0, :a)
     @test m3 == m0
     # 
-    fixpars(m1, (:a,:b)) == fixpars(m1, [:a,:b])
+    fixpars(m1, (:a, :b)) == fixpars(m1, [:a, :b])
     # 
     @test m1 == releasepars(m2, (:a,))
     @test m1 == releasepars(m2, [:a])
     # 
     m4 = updatepars(m0, (a=4, b=5))
-    @test freepars(m4) == (a=4,b=5)
+    @test freepars(m4) == (a=4, b=5)
 end
 
 @testset "func on scalars" begin
     scalar_function = 1.1
     @test func(scalar_function, 3.3) == 1.1
-    @test pars(scalar_function, rand([true,false])) == ∅
+    @test pars(scalar_function, rand([true, false])) == ∅
     # 
     Function_function = sin
     @test func(Function_function, 0.0) ≈ 0.0
-    @test pars(Function_function, rand([true,false])) == ∅
+    @test pars(Function_function, rand([true, false])) == ∅
 end
 
 @testset "lambda constructors" begin
-    g = FGauss(Ext(;μ=1.1,σ=2.2))
+    g = FGauss(Ext(; μ=1.1, σ=2.2))
     # 
     g′ = g |> updatepar(:μ, 1.2)
     @test pars(g′).μ == 1.2
@@ -97,11 +97,11 @@ end
     g′ = g |> fixpar(:μ, 1.2)
     @test pars(g′).μ == 1.2
     # 
-    g′ = g |> updatepars((μ=2.2,σ=3.3))
+    g′ = g |> updatepars((μ=2.2, σ=3.3))
     @test pars(g′).μ == 2.2
     @test pars(g′).σ == 3.3
     # 
-    g′ = g |> fixpars((μ=2.2,σ=3.3))
+    g′ = g |> fixpars((μ=2.2, σ=3.3))
     @test fixedpars(g′).μ == 2.2
     @test fixedpars(g′).σ == 3.3
 end
@@ -109,36 +109,36 @@ end
 @testset "Divide Norm" begin
     g = FGauss((μ=0.0, σ=2.2))
     # 
-    gn = dividenorm(g, :N, (-2,2))
+    gn = dividenorm(g, :N, (-2, 2))
     @test :N ∈ keys(pars(gn))
     @test quadgk(gn, -2, 2)[1] ≈ 1.0
     # 
-    gn′ = g |> dividenorm(:N, (-2,2))
+    gn′ = g |> dividenorm(:N, (-2, 2))
     @test gn′ == gn
 end
 
 
 @testset "FAbs2" begin
     m0 = FunctionWithParameters(
-        (x;p)->p.a+cos(x)*p.b;
-        p=Ext(a=2,b=1))
+        (x; p) -> p.a + cos(x) * p.b;
+        p=Ext(a=2, b=1))
     # 
     am0 = abs2(m0)
-    @test func(am0,π/2) == 4 
+    @test func(am0, π / 2) == 4
     am1 = updatepar(am0, :a, 5)
-    @test func(am1,π/2) == 25
+    @test func(am1, π / 2) == 25
     @test freepars(am0) == freepars(m0)
 end
 
 @testset "FLog" begin
     m0 = FunctionWithParameters(
-        (x;p)->exp(p.b*x);
+        (x; p) -> exp(p.b * x);
         p=Ext(b=2,))
     # 
     am0 = log(m0)
-    @test am0(1) == 2 
+    @test am0(1) == 2
     am1 = updatepar(am0, :b, 4)
-    @test am1(π/2) ≈ 2π
+    @test am1(π / 2) ≈ 2π
     @test freepars(am0) == freepars(m0)
 end
 
@@ -151,19 +151,19 @@ end
     @test nll == minussum(log(d), data)
     @test nll(0.0) != 0.0
     @test nll(0.0) == nll(10.0)
-    @test nll(0.0; p=(m=1, Γ=2)) == nll(0.0, [1,2])
+    @test nll(0.0; p=(m=1, Γ=2)) == nll(0.0, [1, 2])
     @test pars(nll) == pars(d)
     #
     g = Normalized(abs2(FBreitWigner((M=1.1, G=0.3))), (-3, 5))
-    s = d+g
+    s = d + g
     nllsum = NegativeLogLikelihood(s, data)
-    @test nllsum(0.0; p=pars(nllsum)+(α1=0.3, α2=0.7)) ≈ nll(0.0)
+    @test nllsum(0.0; p=merge(pars(nllsum), (α1=0.3, α2=0.7))) ≈ nll(0.0)
     # 
     enll = Extended(NegativeLogLikelihood(s, data))
     @test pars(enll) == pars(s)
     # 
     enll_unit = updatepars(enll, (α1=300, α2=700))
-    @test enll_unit(0.0) ≈ nll(0.0) - log(N)*N + N
+    @test enll_unit(0.0) ≈ nll(0.0) - log(N) * N + N
 end
 
 
@@ -171,64 +171,64 @@ end
     μ₀, σ = 1.1, 1.3
     Δμ = 1.2
     # 
-    g = FGauss((;μ=μ₀,σ))
+    g = FGauss((; μ=μ₀, σ))
     xv = range(-3, 6, length=40)
     yv = g(xv)
     # 
-    χ² = ChiSq(g,collect(xv) .+ Δμ,yv)
+    χ² = ChiSq(g, collect(xv) .+ Δμ, yv)
     #
     @test pars(χ²) == pars(g)
     @test χ²(1.1) ≈ χ²(2.2)
-    @test χ²(1.1; p=(;μ=μ₀+Δμ,σ))+5.5 ≈ 5.5
+    @test χ²(1.1; p=(; μ=μ₀ + Δμ, σ)) + 5.5 ≈ 5.5
     # 
     @show AlgebraPDF.model(χ²) == g
     # 
-    χ²′ = updatepar(χ², :μ, μ₀+Δμ)
-    @test χ²′(1.1)+5.5 ≈ χ²′(2.2)+5.5
-    @test χ²′(1.1)+5.5 ≈ 5.5
+    χ²′ = updatepar(χ², :μ, μ₀ + Δμ)
+    @test χ²′(1.1) + 5.5 ≈ χ²′(2.2) + 5.5
+    @test χ²′(1.1) + 5.5 ≈ 5.5
     # 
 end
 
 @testset "FSum and FProd" begin
     a1 = FunctionWithParameters(
-        (x;p)->p.a+cos(x)*p.b; p=Ext(a=2,b=1))
+        (x; p) -> p.a + cos(x) * p.b; p=Ext(a=2, b=1))
     a2 = FunctionWithParameters(
-        (x;p)->p.a+sin(x)*p.b; p=Ext(a=2,b=1))
+        (x; p) -> p.a + sin(x) * p.b; p=Ext(a=2, b=1))
     #
-    sum1 = a1+a2
-    sum2 = +(a1,a2;p=(c1=1.0,c2=1.0))
-    sum3 = +(a1,a2;p=Ext(d1=1.0, d2=1.0))
+    sum1 = a1 + a2
+    sum2 = +(a1, a2; p=(c1=1.0, c2=1.0))
+    sum3 = +(a1, a2; p=Ext(d1=1.0, d2=1.0))
 
-    @test func(sum1,2) == func(sum2,2)
-    @test func(sum1,2) == func(sum3,2)
+    @test func(sum1, 2) == func(sum2, 2)
+    @test func(sum1, 2) == func(sum3, 2)
 
     @test freepars(sum1) == (a=2, b=1, α1=1.0, α2=1.0)
     @test freepars(sum2) == (a=2, b=1, c1=1.0, c2=1.0)
     @test freepars(sum3) == (a=2, b=1, d1=1.0, d2=1.0)
     # 
-    @test freepars(fixpar(sum3,:a)) == (b=1, d1=1.0, d2=1.0)
+    @test freepars(fixpar(sum3, :a)) == (b=1, d1=1.0, d2=1.0)
     # 
     sum4 = fixpar(sum3, :a, 3)
     @test fixedpars(sum4) == (a=3,)
     @test fixedpars(sum4[1]) == (a=3,)
     @test fixedpars(sum4[2]) == (a=3,)
     #
-    sum5 = fixpar(sum3,:d2, 2)
-    @test func(sum5,3.3) == func(a1,3.3) + 2* func(a2,3.3)
+    sum5 = fixpar(sum3, :d2, 2)
+    @test func(sum5, 3.3) == func(a1, 3.3) + 2 * func(a2, 3.3)
     # 
-    sum6 = a1-a2
-    @test sum6(1.1) == a1(1.1)-a2(1.1)
+    sum6 = a1 - a2
+    @test sum6(1.1) == a1(1.1) - a2(1.1)
     # 
-    prd = a1*a2
-    @test prd(1.1) == a1(1.1)*a2(1.1)
+    prd = a1 * a2
+    @test prd(1.1) == a1(1.1) * a2(1.1)
 end
 
 
 @testset "no-parameters f and no-parameters normalized f" begin
-    d0 = FunctionWithParameters((e;p)->e^2+p.a; p=(a=1.0,))
+    d0 = FunctionWithParameters((e; p) -> e^2 + p.a; p=(a=1.0,))
     f0 = noparsf(d0)
     xv = -1:10
-    @test func(d0,xv;p=freepars(d0)) ≈ f0(xv)
+    @test func(d0, xv; p=freepars(d0)) ≈ f0(xv)
 end
 
 
@@ -236,12 +236,12 @@ end
 struct BW1{P} <: AbstractFunctionWithParameters
     p::P
 end
-import AlgebraPDF:func
-func(bw::BW1, x::NumberOrTuple; p=pars(bw)) = p.m*p.Γ/(p.m^2-x^2-1im*p.m*p.Γ)
+import AlgebraPDF: func
+func(bw::BW1, x::NumberOrTuple; p=pars(bw)) = p.m * p.Γ / (p.m^2 - x^2 - 1im * p.m * p.Γ)
 
 
 @testset "User-def type with fixed name" begin
-    bw = BW1((m=3.1,Γ=0.1))
+    bw = BW1((m=3.1, Γ=0.1))
     @test pars(bw).m == 3.1
     @test pars(bw).Γ == 0.1
     @test bw(1.1) != 0.0
@@ -253,25 +253,25 @@ struct BW2{P} <: AbstractFunctionWithParameters
     p::P
 end
 function AlgebraPDF.func(bw::BW2, x::NumberOrTuple; p=AlgebraPDF.pars(bw))
-    m,Γ = (getproperty(p,s) for s in keys(bw.p))
-    m*Γ/(m^2-x^2-1im*m*Γ)
+    m, Γ = (getproperty(p, s) for s in keys(bw.p))
+    m * Γ / (m^2 - x^2 - 1im * m * Γ)
 end
 
 
 @testset "User-def type with fixed order" begin
-    bw = BW2((m1=3.1,Γ1=0.1))
+    bw = BW2((m1=3.1, Γ1=0.1))
     # 
     @test pars(bw).m1 == 3.1
     @test pars(bw).Γ1 == 0.1
     @test real(bw(3.1)) ≈ 0.0
-    @test real(bw(3.1; p=(m1=1.1,Γ1=3.3))) != 0
+    @test real(bw(3.1; p=(m1=1.1, Γ1=3.3))) != 0
     # 
-    bw = BW2((m2=3.1,Γ2=0.1))
+    bw = BW2((m2=3.1, Γ2=0.1))
     @test pars(bw).m2 == 3.1
     @test pars(bw).Γ2 == 0.1
 end
 
-@makefuntype SuperF(x;p) = x^2+p.a*x^3
+@makefuntype SuperF(x; p) = x^2 + p.a * x^3
 g = SuperF(p=(a=0.5,))
 
 @testset "@maketype macro" begin

--- a/test/testparameters.jl
+++ b/test/testparameters.jl
@@ -2,45 +2,45 @@
 using AlgebraPDF
 
 @testset "Parameter utils" begin
-    @test nt(:d) == (d=0.0, )
-    @test nt(:d, 3) == (d=3, )
-    @test nt(:d, (1.1,0.1)) == (d = (1.1,0.1), )
+    @test nt(:d) == (d=0.0,)
+    @test nt(:d, 3) == (d=3,)
+    @test nt(:d, (1.1, 0.1)) == (d=(1.1, 0.1),)
 end
 
 @testset "Operations on NamedTuple" begin
-    @test (a=1,b=2) + (d=1,c=2) == (a=1,b=2,d=1,c=2)
-    @test (a=1,b=2,d=1,c=2) - (d=1,) == (a=1,b=2,c=2)
-    @test (a=1,b=2,d=1,c=2) - :d == (a=1,b=2,c=2)
-    @test (a=1,b=2,d=1,c=2) - [:d, :a] == (b=2,c=2)
-    @test (a=1,b=2,d=1,c=2) - (:d, :a) == (b=2,c=2)
+    @test merge((a=1, b=2), (d=1, c=2)) == (a=1, b=2, d=1, c=2)
+    @test subtract((a=1, b=2, d=1, c=2), (d=1,)) == (a=1, b=2, c=2)
+    @test subtract((a=1, b=2, d=1, c=2), :d) == (a=1, b=2, c=2)
+    @test subtract((a=1, b=2, d=1, c=2), [:d, :a]) == (b=2, c=2)
+    @test subtract((a=1, b=2, d=1, c=2), (:d, :a)) == (b=2, c=2)
 end
 
 
 @testset "Parameter structure: NamedTuple" begin
-    p0 = (a=1,b=2)
+    p0 = (a=1, b=2)
     @test pars(p0) == p0
     @test freepars(p0) == p0
     @test fixedpars(p0) == ∅
-    @test AlgebraPDF.updatevalueorflag(p0, :a, true, 2) == (a=2,b=2)
+    @test AlgebraPDF.updatevalueorflag(p0, :a, true, 2) == (a=2, b=2)
     @test_throws ArgumentError AlgebraPDF.updatevalueorflag(p0, :a, false)
 end
 
 
 @testset "Parameter structure: FlaggedNamedTuple" begin
     #
-    p0 = FlaggedNamedTuple(a=1,b=2)
+    p0 = FlaggedNamedTuple(a=1, b=2)
     @test p0.a == 1
     @test p0.b == 2
     # 
     p1 = AlgebraPDF.updatevalueorflag(p0, :a, true, 2)
-    @test pars(p1) == (a=2,b=2)
+    @test pars(p1) == (a=2, b=2)
     #
     p2 = AlgebraPDF.updatevalueorflag(p0, :a, false)
     @test pars(p0) == pars(p2)
     @test freepars(p2) == (b=2,)
     @test fixedpars(p2) == (a=1,)
     #
-    @test p0 == FlaggedNamedTuple((a=1,b=2))
+    @test p0 == FlaggedNamedTuple((a=1, b=2))
     @test p2 == FlaggedNamedTuple(p2)
     # 
     @test keys(p1) == keys(p2)
@@ -48,19 +48,19 @@ end
     @test keys(p2, false) == (:a,)
 end
 
-@testset "Addind parameter sets: FNT+FNT, FNT+NT, NT+FNT" begin 
-    p1 = FlaggedNamedTuple(a1=1,b1=2)
-    p2 = FlaggedNamedTuple(a2=1,b2=2)
-    p12 = p1 + p2
-    @test pars(p12) == pars(p1) + pars(p2)
+@testset "Addind parameter sets: FNT+FNT, FNT+NT, NT+FNT" begin
+    p1 = FlaggedNamedTuple(a1=1, b1=2)
+    p2 = FlaggedNamedTuple(a2=1, b2=2)
+    p12 = merge(p1, p2)
+    @test pars(p12) == merge(pars(p1), pars(p2))
 
     p2′ = AlgebraPDF.updatevalueorflag(p2, :a2, false)
-    p12′ = p1 + p2′
-    @test pars(p12′, true) == pars(p1, true) + pars(p2′, true)
-    @test pars(p12′, false) == pars(p1, false) + pars(p2′, false)
+    p12′ = merge(p1, p2′)
+    @test pars(p12′, true) == merge(pars(p1, true), pars(p2′, true))
+    @test pars(p12′, false) == merge(pars(p1, false), pars(p2′, false))
 
-    pd1′′ = p12′ + (d4=2.2, )
-    pd2′′ = (d4=2.2, ) + p12′
+    pd1′′ = merge(p12′, (d4=2.2,))
+    pd2′′ = merge((d4=2.2,), p12′)
     @test :d4 ∈ keys(freepars(pd1′′))
     @test :d4 ∈ keys(freepars(pd2′′))
 end

--- a/test/testsum.jl
+++ b/test/testsum.jl
@@ -2,39 +2,39 @@
 using AlgebraPDF
 using Test
 
-g1 = FGauss((μ1=1.1,σ1=0.1))
-g2 = FGauss((μ2=2.2,σ2=0.2))
-g3 = FGauss((μ3=3.3,σ3=0.3))
-d = AlgebraPDF.FSum([g1,g2,g3], (α1=0.1,α2=0.2,α3=0.3))
-d2 = AlgebraPDF.FSum([g1,g2,g3], Ext(α1=0.1,α2=0.2,α3=0.3)) |> x->fixpar(x, :α1)
+g1 = FGauss((μ1=1.1, σ1=0.1))
+g2 = FGauss((μ2=2.2, σ2=0.2))
+g3 = FGauss((μ3=3.3, σ3=0.3))
+d = AlgebraPDF.FSum([g1, g2, g3], (α1=0.1, α2=0.2, α3=0.3))
+d2 = AlgebraPDF.FSum([g1, g2, g3], Ext(α1=0.1, α2=0.2, α3=0.3)) |> x -> fixpar(x, :α1)
 
-@testset "Sum of regular functions" begin 
+@testset "Sum of regular functions" begin
     @test length(d) == 3
     @test abs(func(d, 1.5)) < 0.01
-    @test abs(func(d, 1.5; p=pars(d)+(μ1=1.5,))) > 0.01
-    @test func(d, 1.5; p=pars(d)+(α1=1500,)) > 0.01
+    @test abs(func(d, 1.5; p=merge(pars(d), (μ1=1.5,)))) > 0.01
+    @test func(d, 1.5; p=merge(pars(d), (α1=1500,))) > 0.01
     # 
-    @test abs(d(1.1)-d(2.2)) < 0.01
-    @test abs(d(2.2)-d(3.3)) < 0.01
+    @test abs(d(1.1) - d(2.2)) < 0.01
+    @test abs(d(2.2) - d(3.3)) < 0.01
 
     keys(fixedpars(d2)) == (:α1,)
     @test d2(1.1) == d(1.1)
 end
 #
 
-ng1 = Normalized(g1, (1,4))
-ng2 = Normalized(g2, (1,4))
-ng3 = Normalized(g3, (1,4))
-nd = FSum([ng1,ng2,ng3], (α1=0.1,α2=0.2,α3=0.3))
+ng1 = Normalized(g1, (1, 4))
+ng2 = Normalized(g2, (1, 4))
+ng3 = Normalized(g3, (1, 4))
+nd = FSum([ng1, ng2, ng3], (α1=0.1, α2=0.2, α3=0.3))
 # 
-@testset "Sum of normalized functions" begin 
+@testset "Sum of normalized functions" begin
 
-    @test typeof(d) <: FSum{T} where T<:AbstractFunctionWithParameters
-    @test typeof(nd) <: FSum{T} where T<:AbstractPDF
+    @test typeof(d) <: FSum{T} where {T<:AbstractFunctionWithParameters}
+    @test typeof(nd) <: FSum{T} where {T<:AbstractPDF}
 
     @test func(nd, 1.1) isa Number
-    @test func(nd, [1.1,1,1])  isa Vector
-    @test func(nd, 1:0.1:2)  isa Vector
+    @test func(nd, [1.1, 1, 1]) isa Vector
+    @test func(nd, 1:0.1:2) isa Vector
 
     @test lims(nd) == lims(ng1)
 
@@ -59,7 +59,7 @@ end
 
 @testset "Multiplication: c * FSum, FSum * c " begin
     @test d == (α1=0.1,) * g1 + (α2=0.2,) * g2 + (α3=0.3,) * g3
-    x2 = (Ext(α1=0.1,) * g1 + (α2=0.2,) * g2 + (α3=0.3,) * g3) |> d->fixpar(d,:α1)
+    x2 = (Ext(α1=0.1,) * g1 + (α2=0.2,) * g2 + (α3=0.3,) * g3) |> d -> fixpar(d, :α1)
     @test typeof(d2) == typeof(x2) && d2.fs == x2.fs && d2.αs == x2.αs
-    @test nd == (α1=0.1,) * ng1 + (α2=0.2,) * ng2 + (α3=0.3,) * ng3    
+    @test nd == (α1=0.1,) * ng1 + (α2=0.2,) * ng2 + (α3=0.3,) * ng3
 end


### PR DESCRIPTION
The package was defining `+` and `-` operation between `NamedTuple`s and `Symbol`s, which is not in `Base`.
The operations are renamed to `merge` and `subtract`, now.